### PR TITLE
meowmeowcatcam

### DIFF
--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -569,6 +569,10 @@ def main():
     )
 
     memes = load_memes()
+    # widest aspect ratio across every meme image, so the meme window can be
+    # given exactly enough room for the biggest one up front, instead of
+    # discovering mid-session that some meme doesn't fit
+    max_meme_aspect = max(img.shape[1] / img.shape[0] for imgs in memes.values() for img in imgs)
     memes["_current"] = random.choice(memes["default"])
     memes["_spin_restart"] = False
 
@@ -582,6 +586,10 @@ def main():
     spin_video_cap = cv2.VideoCapture(str(MEMES / GESTURE_MEMES["spinCat"][0]))
     if not spin_video_cap.isOpened():
         raise FileNotFoundError(f"missing meme file: {MEMES / GESTURE_MEMES['spinCat'][0]}")
+    spin_w = spin_video_cap.get(cv2.CAP_PROP_FRAME_WIDTH)
+    spin_h = spin_video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
+    if spin_w and spin_h:
+        max_meme_aspect = max(max_meme_aspect, spin_w / spin_h)
 
     def next_spin_frame():
         ok, vframe = spin_video_cap.read()
@@ -643,12 +651,17 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
-        # cam window is sized ONCE here, to its own aspect ratio maximized
-        # within 2/3 of the screen's width, and never touched again -
-        # nothing the meme does (including its own size) can resize the cam.
+        # reserve just enough width for the biggest meme at full height, plus
+        # a small gap so the two windows don't sit glued together - the cam
+        # gets everything else. Sized once, never touched again: no meme,
+        # however big, ever needs more room than this, so the cam never has
+        # to resize or get overlapped.
+        WINDOW_GAP = 24
+        meme_max_w = int(max_meme_aspect * avail_h)
         first_frame = shared_frame.get()
-        cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w * 2 // 3, avail_h)
-        meme_max_w = screen_w - cam_w  # whatever's left over, meme fits within - never touches the cam
+        cam_w, cam_h = fit_within(
+            first_frame.shape[1], first_frame.shape[0], screen_w - meme_max_w - WINDOW_GAP, avail_h
+        )
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
         cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -648,7 +648,6 @@ def main():
         # nothing the meme does (including its own size) can resize the cam.
         first_frame = shared_frame.get()
         cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w * 2 // 3, avail_h)
-        meme_max_w = screen_w - cam_w  # whatever's left over, meme fits within - never touches the cam
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
         cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
@@ -675,7 +674,13 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            meme_w, meme_h = fit_within(meme_img.shape[1], meme_img.shape[0], meme_max_w, avail_h)
+            # always fill the full available height - never shrink it to
+            # stay within the leftover width. If it needs more width than
+            # that, it overlaps the cam window instead (right-anchored, so
+            # it grows leftward over the cam rather than off the screen).
+            meme_aspect = meme_img.shape[1] / meme_img.shape[0]
+            meme_h = avail_h
+            meme_w = max(1, int(meme_aspect * meme_h))
 
             cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -599,8 +599,12 @@ def main():
     # own negotiation that tends to pick a much better encode than
     # AVFoundation's default). MJPG gives the camera more bandwidth
     # headroom to hit both the resolution and the fps target.
+    # 4:3 instead of 16:9 - the cam window sits in a half-screen column,
+    # which is narrower than it is wide, so a 16:9 frame ends up short
+    # (looks small) once scaled to fit that column. 4:3 is much closer to
+    # the column's own aspect ratio, so it scales up bigger.
     cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 960)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
     cap.set(cv2.CAP_PROP_FPS, 30)
     cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)  # always grab the newest frame, not a queued stale one

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -404,10 +404,26 @@ def draw_debug_hud(frame, state, gesture):
         f"spin fraction (2.2s window): {state.last_flow_fraction_debug:.2f}  (thr {SPIN_FRACTION_REQUIRED:.2f})",
         f"peak score (last 2s): {state.last_flow_peak_debug:.2f}  <- read this AFTER you stop spinning",
     ]
+
+    font, scale, thick, outline = cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1, 3
+    pad, line_h = 8, 20
+    # measure with the outline thickness, not the fill thickness - the dark
+    # outline is what actually sets how far the text reaches - and allow for
+    # it overhanging the reported advance width on both sides
+    text_w = max(cv2.getTextSize(l, font, scale, outline)[0][0] for l in lines) + outline * 2
+
+    # dark panel behind the text - the readout used to sit directly on the
+    # camera image, where thin green glyphs washed out over bright or busy
+    # areas of the frame
+    panel_w = min(frame.shape[1], pad * 2 + text_w)
+    panel_h = min(frame.shape[0], pad * 2 + line_h * len(lines))
+    panel = frame[0:panel_h, 0:panel_w]
+    cv2.addWeighted(panel, 0.15, np.zeros_like(panel), 0.85, 0, panel)
+
     for i, line in enumerate(lines):
-        y = 24 + i * 22
-        cv2.putText(frame, line, (10, y), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 0, 0), 3, cv2.LINE_AA)
-        cv2.putText(frame, line, (10, y), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 120), 1, cv2.LINE_AA)
+        y = pad + line_h * i + 14
+        cv2.putText(frame, line, (pad, y), font, scale, (0, 0, 0), 3, cv2.LINE_AA)
+        cv2.putText(frame, line, (pad, y), font, scale, (0, 255, 120), thick, cv2.LINE_AA)
 
 
 def draw_landmarks(frame, hand_result):
@@ -696,7 +712,12 @@ def main():
             frame = shared_frame.get()
             if frame is None:
                 continue
-            frame = frame.copy()
+            # scale to display size FIRST, then draw - the overlays used to
+            # be drawn on the full 1280-wide frame and shrunk with it, which
+            # made the readout text noticeably smaller than intended (and
+            # meant drawing more pixels than needed). Landmarks use
+            # normalized coords, so they scale to any size.
+            frame = cv2.resize(frame, (cam_w, cam_h))
 
             hand_result, current_gesture = shared_detection.get()
             if hand_result is not None:
@@ -715,7 +736,7 @@ def main():
             # own aspect ratio, no bars; only the spin video hits max_w
             meme_view = fit_meme(meme_img, display_h, meme_max_w)
 
-            cv2.imshow("Camera", cv2.resize(frame, (cam_w, cam_h)))
+            cv2.imshow("Camera", frame)
             cv2.imshow("Meme", meme_view)
 
             # no delay beyond what's needed to pump the GUI event loop - the

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -91,20 +91,24 @@ STABLE_FRAMES_TO_LEAVE = 12
 DEFAULT_FALLBACK_MS = 600
 FACE_STALE_MS = 1200
 
-# For a gesture with several memes, one is picked at random each time the
-# gesture is (re)entered. Finger classification uses a hard angle cutoff,
-# so a finger held near that cutoff flickers: a real recording of holding
-# one finger up produced 106 runs of oneFingerUp, bouncing mostly to fist
-# and default, and 38 of them survived debouncing - each re-picking an
-# image, so the meme visibly flapped between profcat and professorcat
-# while the hand never moved.
+# For a gesture with several memes, which one shows changes only after a
+# genuine rest, not on every re-entry.
 #
-# So: re-entering a gesture this soon after leaving it reuses the image it
-# had, and only a genuine gap picks a new one. Replaying that recording
-# through the debounce, this plus STABLE_FRAMES_TO_LEAVE takes the visible
-# image swaps while holding one finger up from ~18 down to ~1 (averaged
-# over 30 random seeds).
-MEME_REROLL_MS = 10000
+# Finger classification uses a hard angle cutoff, so a finger held near it
+# flickers: a real recording of holding one finger up produced 106 runs of
+# oneFingerUp, bouncing mostly to fist and default, 38 of which survived
+# debouncing. Picking an image on each of those made the meme flap between
+# profcat and professorcat while the hand never moved.
+#
+# Rest is defined as the sustained-default state below (DEFAULT_FALLBACK_MS
+# with no gesture), which a momentary misclassification doesn't reach. So
+# holding a gesture keeps one image no matter how much the classifier
+# wobbles, while lowering your hands and posing again always advances.
+#
+# Advancing in order rather than at random also means every image in a set
+# is reachable: with random picks a 3-image set could go many tries without
+# showing a given one.
+
 
 # how far the head has to turn (yaw, in degrees, from MediaPipe's own head
 # pose estimate - not a hand-rolled distance heuristic) to count as a
@@ -300,6 +304,7 @@ class GestureState:
         self.last_hands_debug = 0
         self.last_pointing_debug = 0
         self.last_tip_gap_debug = 0.0
+        self.last_fingers_debug = ""
         self.flow_history = []  # [(t, magnitude), ...] trailing samples, for the fraction-above trigger
         self.flow_peak_history = []  # [(t, score), ...] longer trailing window, for the readable peak display
         self.last_flow_magnitude_debug = 0.0
@@ -402,6 +407,15 @@ class GestureState:
             self.last_pointing_debug = sum(1 for h in hands if is_pointing(h))
             avg_scale = (hands[0]["handScale"] + hands[1]["handScale"]) / 2
             self.last_tip_gap_debug = dist(hands[0]["indexTip"], hands[1]["indexTip"]) / avg_scale
+            # which fingers each hand reads as extended, as index/middle/
+            # ring/pinky bits - recorded because tip_gap turned out to pass
+            # on every two-hand frame while pointing never reached 2, so the
+            # finger test is what blocks this gesture and this says which
+            # finger is responsible.
+            self.last_fingers_debug = "|".join(
+                "".join(str(int(h[k])) for k in ("indexUp", "middleUp", "ringUp", "pinkyUp"))
+                for h in hands
+            )
 
             if is_pointing(hands[0]) and is_pointing(hands[1]):
                 if self.last_tip_gap_debug < 1.4:
@@ -637,16 +651,20 @@ def detection_loop(
     candidate_streak = 0
     last_non_default_at = time.time() * 1000
     start_time = time.time()
-    # gesture -> (chosen image, when it was last on screen), so a gesture
-    # flickering out and back keeps its image instead of re-rolling
-    meme_choice = {}
+    # gesture -> index of the image currently assigned to it. Advanced only
+    # after a rest, so a gesture flickering out and back keeps its image.
+    meme_index = {}
+    rested = True  # no gesture has been struck yet, so the next one is fresh
 
-    def pick_meme(gesture, now):
-        img, last_seen = meme_choice.get(gesture, (None, None))
-        if img is None or now - last_seen > MEME_REROLL_MS:
-            img = random.choice(memes[gesture])
-        meme_choice[gesture] = (img, now)
-        return img
+    def pick_meme(gesture):
+        options = memes[gesture]
+        i = meme_index.get(gesture)
+        if i is None:
+            i = random.randrange(len(options))  # don't always open on the same one
+        elif rested:
+            i = (i + 1) % len(options)
+        meme_index[gesture] = i
+        return options[i]
 
     while not stop_event.is_set():
         frame = shared_frame.get()
@@ -677,7 +695,7 @@ def detection_loop(
             f"{state.last_mouth_open_debug:.4f},{state.last_yaw_debug:.2f},"
             f"{state.last_roll_debug:.2f},{int(state.face_seen_this_frame)},"
             f"{state.last_hands_debug},{state.last_pointing_debug},"
-            f"{state.last_tip_gap_debug:.3f},"
+            f"{state.last_tip_gap_debug:.3f},{state.last_fingers_debug},"
             f"{gesture},{current_gesture}\n"
         )
 
@@ -697,18 +715,25 @@ def detection_loop(
                 if gesture == "spinCat":
                     memes["_spin_restart"] = True
             elif gesture in memes:
-                memes["_current"] = pick_meme(gesture, now)
+                memes["_current"] = pick_meme(gesture)
             # else: gesture is wired up but its artwork isn't in memes/ yet
             # (load_memes said so at startup). Still switch to it so the
             # readout names it - that's what makes the detection tunable
             # before the art exists - and leave the meme window showing
             # whatever it had.
+            if gesture != "default":
+                rested = False  # spend the rest on this pose
 
         if gesture != "default":
             last_non_default_at = now
-        elif now - last_non_default_at > DEFAULT_FALLBACK_MS and current_gesture != "default":
-            current_gesture = "default"
-            memes["_current"] = pick_meme("default", now)
+        elif now - last_non_default_at > DEFAULT_FALLBACK_MS:
+            # settled back to no gesture at all - long enough that a
+            # momentary misread can't cause it. That's a real rest, so the
+            # next pose gets to move on to its next image.
+            rested = True
+            if current_gesture != "default":
+                current_gesture = "default"
+                memes["_current"] = pick_meme("default")
 
         shared_detection.set(hand_result, current_gesture)
 
@@ -749,7 +774,7 @@ def main():
     flow_log = open(flow_log_path, "w", buffering=1)  # line-buffered so data survives a hard kill
     flow_log.write(
         "t_ms,magnitude,coherence,score,fraction,peak_2s,"
-        "mouth_open,yaw,roll,face_seen,hands,pointing,tip_gap,"
+        "mouth_open,yaw,roll,face_seen,hands,pointing,tip_gap,fingers,"
         "gesture_raw,gesture_shown\n"
     )
 

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -8,7 +8,7 @@ Opens two windows, side by side like the OBS/streamer setups:
 Gestures:
   rockstar / shaka  -> memes/cat.jpg
   default (no hand) -> memes/pokercat.jpg
-  one finger up     -> memes/profcat.jpg, memes/professorcat.jpg
+  one finger up     -> memes/professorcat.jpg
   fist / punch      -> memes/punchcat.jpg
   shhh              -> memes/shhcat.jpg
   two fingers together (both hands, tips touching) -> memes/uwucat.jpg, memes/uwucatt.jpg,
@@ -61,7 +61,7 @@ MEMES = ROOT / "memes"
 GESTURE_MEMES = {
     "rockstar": ["cat.jpg"],
     "default": ["pokercat.jpg"],
-    "oneFingerUp": ["profcat.jpg", "professorcat.jpg"],
+    "oneFingerUp": ["professorcat.jpg"],
     "fist": ["punchcat.jpg"],
     "shhh": ["shhcat.jpg"],
     "twoFingersTogether": ["uwucat.jpg", "uwucatt.jpg", "fingers together muehehe .jpg"],

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -609,11 +609,6 @@ def detection_loop(
 
         magnitude, coherence, prev_flow_gray = frame_flow_signal(frame, prev_flow_gray)
         state.update_flow(magnitude, coherence)
-        flow_log.write(
-            f"{time.time() * 1000:.0f},{magnitude:.4f},{coherence:.4f},"
-            f"{state.last_flow_score_debug:.4f},{state.last_flow_fraction_debug:.4f},"
-            f"{state.last_flow_peak_debug:.4f},{current_gesture}\n"
-        )
 
         rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         mp_image = Image(image_format=ImageFormat.SRGB, data=rgb)
@@ -624,6 +619,18 @@ def detection_loop(
         state.update_face(face_result)
 
         gesture = state.decide(hand_result)
+
+        # logged after detection, so every column is from this same frame -
+        # the face columns are here to tune the mouth/roll thresholds
+        # against real recordings rather than by guesswork
+        flow_log.write(
+            f"{time.time() * 1000:.0f},{magnitude:.4f},{coherence:.4f},"
+            f"{state.last_flow_score_debug:.4f},{state.last_flow_fraction_debug:.4f},"
+            f"{state.last_flow_peak_debug:.4f},"
+            f"{state.last_mouth_open_debug:.4f},{state.last_yaw_debug:.2f},"
+            f"{state.last_roll_debug:.2f},{int(state.face_seen_this_frame)},"
+            f"{gesture},{current_gesture}\n"
+        )
 
         now = time.time() * 1000
         if gesture == candidate_gesture:
@@ -688,7 +695,10 @@ def main():
     # instead of trying to read a jittery number while dizzy.
     flow_log_path = ROOT / "flow_debug_log.csv"
     flow_log = open(flow_log_path, "w", buffering=1)  # line-buffered so data survives a hard kill
-    flow_log.write("t_ms,magnitude,coherence,score,fraction,peak_2s,gesture\n")
+    flow_log.write(
+        "t_ms,magnitude,coherence,score,fraction,peak_2s,"
+        "mouth_open,yaw,roll,face_seen,gesture_raw,gesture_shown\n"
+    )
 
     spin_video_cap = cv2.VideoCapture(str(MEMES / GESTURE_MEMES["spinCat"][0]))
     if not spin_video_cap.isOpened():

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -419,11 +419,20 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-# scale an image's own aspect ratio to the largest size that fits within a
-# box, without cropping or distorting it.
-def fit_within(img_w, img_h, box_w, box_h):
-    scale = min(box_w / img_w, box_h / img_h)
-    return max(1, int(img_w * scale)), max(1, int(img_h * scale))
+# Give the cam and meme windows a fair, uncropped share of the screen: both
+# get the SAME height, and each one's width follows from its own aspect
+# ratio (a wide 16:9 cam naturally needs more width than a near-square meme
+# to reach the same height). A fixed half-and-half column split doesn't work
+# here - the cam is much wider than most meme images, so at equal width the
+# cam would end up much shorter (looking tiny) while the meme fills the
+# column (looking huge). Use the full available height if both fit
+# side-by-side at that height; otherwise shrink both together until they do.
+def split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h):
+    h = avail_h
+    if (cam_aspect + meme_aspect) * h > screen_w:
+        h = screen_w / (cam_aspect + meme_aspect)
+    h = int(h)
+    return max(1, int(cam_aspect * h)), h, max(1, int(meme_aspect * h)), h
 
 
 def get_screen_size():
@@ -639,21 +648,11 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
-        # cam window is sized ONCE here, to its own aspect ratio maximized
-        # across the whole screen, and never touched again - the meme window
-        # never affects it.
         first_frame = shared_frame.get()
-        cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w, avail_h)
-        cam_x, cam_y = (screen_w - cam_w) // 2, TOP_MARGIN + (avail_h - cam_h) // 2
+        cam_aspect = first_frame.shape[1] / first_frame.shape[0]
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
-        cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
-        cv2.moveWindow(CAM_WINDOW, cam_x, cam_y)
-
-        # meme window floats on top of the cam window, centered over it,
-        # capped to a fraction of its size so it reads as an overlay rather
-        # than competing with the cam for screen space.
-        MEME_MAX_W, MEME_MAX_H = int(cam_w * 0.5), int(cam_h * 0.6)
+        cv2.moveWindow(CAM_WINDOW, 0, TOP_MARGIN)  # left edge pinned to screen's left edge
         cv2.namedWindow(MEME_WINDOW, cv2.WINDOW_NORMAL)
 
         while not stop_event.is_set():
@@ -676,17 +675,19 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            meme_w, meme_h = fit_within(meme_img.shape[1], meme_img.shape[0], MEME_MAX_W, MEME_MAX_H)
+            meme_aspect = meme_img.shape[1] / meme_img.shape[0]
+            cam_w, cam_h, meme_w, meme_h = split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h)
 
             cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))
             # macOS/Cocoa backend sometimes ignores resizeWindow if it's not
-            # re-applied after imshow, so pin the size every frame. Only the
-            # meme window is resized here - the cam window is fixed above.
+            # re-applied after imshow, so pin the size every frame
+            cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
             cv2.resizeWindow(MEME_WINDOW, meme_w, meme_h)
-            # keep it centered over the cam window as its size changes, so
-            # it grows/shrinks symmetrically instead of drifting to an edge
-            cv2.moveWindow(MEME_WINDOW, cam_x + (cam_w - meme_w) // 2, cam_y + (cam_h - meme_h) // 2)
+            # anchor the Meme window's RIGHT edge to the screen's right edge,
+            # so as the meme's width changes the window grows/shrinks
+            # leftward (into the screen) instead of rightward (off it)
+            cv2.moveWindow(MEME_WINDOW, screen_w - meme_w, TOP_MARGIN)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -297,6 +297,9 @@ class GestureState:
         self.last_yaw_debug = 0.0
         self.last_roll_debug = 0.0
         self.last_mouth_open_debug = 0.0
+        self.last_hands_debug = 0
+        self.last_pointing_debug = 0
+        self.last_tip_gap_debug = 0.0
         self.flow_history = []  # [(t, magnitude), ...] trailing samples, for the fraction-above trigger
         self.flow_peak_history = []  # [(t, score), ...] longer trailing window, for the readable peak display
         self.last_flow_magnitude_debug = 0.0
@@ -389,12 +392,19 @@ class GestureState:
             return "default"
 
         hands = [classify_hand(lm) for lm in hand_result.hand_landmarks]
+        self.last_hands_debug = len(hands)
 
         if len(hands) == 2:
+            # recorded for tuning: how many hands read as pointing, and how
+            # far apart the index tips are. Every observed run of this
+            # gesture was bracketed by crashOutCat, so one of these two is
+            # what drops out and lets the generic near-face pose take over.
+            self.last_pointing_debug = sum(1 for h in hands if is_pointing(h))
+            avg_scale = (hands[0]["handScale"] + hands[1]["handScale"]) / 2
+            self.last_tip_gap_debug = dist(hands[0]["indexTip"], hands[1]["indexTip"]) / avg_scale
+
             if is_pointing(hands[0]) and is_pointing(hands[1]):
-                avg_scale = (hands[0]["handScale"] + hands[1]["handScale"]) / 2
-                tip_gap = dist(hands[0]["indexTip"], hands[1]["indexTip"]) / avg_scale
-                if tip_gap < 1.4:
+                if self.last_tip_gap_debug < 1.4:
                     return "twoFingersTogether"
 
             if face_is_fresh:
@@ -492,6 +502,7 @@ def draw_debug_hud(frame, state, gesture):
         f"yaw  {state.last_yaw_debug:+5.1f}/{SIDE_EYE_YAW_DEG:.0f}",
         f"roll {state.last_roll_debug:+5.1f}/{HUH_ROLL_DEG:.0f}",
         f"mouth {state.last_mouth_open_debug:.2f}/{SCREAM_MOUTH_OPEN:.2f}",
+        f"hands {state.last_hands_debug} pt {state.last_pointing_debug} gap {state.last_tip_gap_debug:.2f}/1.40",
         f"flow {state.last_flow_magnitude_debug:.2f}/{SPIN_MAG_THRESHOLD:.2f}",
         f"spin {state.last_flow_fraction_debug:.2f}/{SPIN_FRACTION_REQUIRED:.2f}"
         f"  pk {state.last_flow_peak_debug:.2f}",
@@ -665,6 +676,8 @@ def detection_loop(
             f"{state.last_flow_peak_debug:.4f},"
             f"{state.last_mouth_open_debug:.4f},{state.last_yaw_debug:.2f},"
             f"{state.last_roll_debug:.2f},{int(state.face_seen_this_frame)},"
+            f"{state.last_hands_debug},{state.last_pointing_debug},"
+            f"{state.last_tip_gap_debug:.3f},"
             f"{gesture},{current_gesture}\n"
         )
 
@@ -736,7 +749,8 @@ def main():
     flow_log = open(flow_log_path, "w", buffering=1)  # line-buffered so data survives a hard kill
     flow_log.write(
         "t_ms,magnitude,coherence,score,fraction,peak_2s,"
-        "mouth_open,yaw,roll,face_seen,gesture_raw,gesture_shown\n"
+        "mouth_open,yaw,roll,face_seen,hands,pointing,tip_gap,"
+        "gesture_raw,gesture_shown\n"
     )
 
     spin_video_cap = cv2.VideoCapture(str(MEMES / GESTURE_MEMES["spinCat"][0]))

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -79,8 +79,32 @@ GESTURE_MEMES = {
 VIDEO_GESTURES = {"spinCat"}
 
 STABLE_FRAMES_REQUIRED = 5
+# Leaving a gesture that's already on screen takes more consecutive frames
+# than entering one does. Finger classification uses a hard angle cutoff,
+# so a finger held near it flickers: in a real recording of simply holding
+# one finger up, oneFingerUp was interrupted 56 times, mostly by fist -
+# interruptions of 2 frames at the median, but 12 of them lasted 5+ frames
+# and so survived the entry threshold. Requiring 12 frames to leave
+# filters 49 of the 56 while still reacting to a real gesture change in
+# under half a second.
+STABLE_FRAMES_TO_LEAVE = 12
 DEFAULT_FALLBACK_MS = 600
 FACE_STALE_MS = 1200
+
+# For a gesture with several memes, one is picked at random each time the
+# gesture is (re)entered. Finger classification uses a hard angle cutoff,
+# so a finger held near that cutoff flickers: a real recording of holding
+# one finger up produced 106 runs of oneFingerUp, bouncing mostly to fist
+# and default, and 38 of them survived debouncing - each re-picking an
+# image, so the meme visibly flapped between profcat and professorcat
+# while the hand never moved.
+#
+# So: re-entering a gesture this soon after leaving it reuses the image it
+# had, and only a genuine gap picks a new one. Replaying that recording
+# through the debounce, this plus STABLE_FRAMES_TO_LEAVE takes the visible
+# image swaps while holding one finger up from ~18 down to ~1 (averaged
+# over 30 random seeds).
+MEME_REROLL_MS = 10000
 
 # how far the head has to turn (yaw, in degrees, from MediaPipe's own head
 # pose estimate - not a hand-rolled distance heuristic) to count as a
@@ -89,11 +113,13 @@ FACE_STALE_MS = 1200
 SIDE_EYE_YAW_DEG = 15.0
 
 # how far the head has to tilt sideways (roll, degrees, same head-pose
-# estimate) for the "huh?" head-tilt look. Set well above SIDE_EYE_YAW_DEG's
-# neighbourhood of casual movement - a deliberate tilt is a big, obvious
-# motion, and a small roll is just how people naturally hold their head.
-# Watch the live "roll" readout while tilting to tune it.
-HUH_ROLL_DEG = 18.0
+# estimate) for the "huh?" head-tilt look.
+#
+# From a real recorded session (flow_debug_log.csv): ordinary head
+# movement kept |roll| under 8.3 for 99% of frames and never went past
+# 15.4, so an 18 threshold could not be reached at all. 12 clears normal
+# movement with margin while staying inside what a deliberate tilt hits.
+HUH_ROLL_DEG = 12.0
 
 # how far open the mouth has to be to count as a scream. Measured as
 # lip-gap over face height (chin to forehead), so it changes neither with
@@ -600,6 +626,16 @@ def detection_loop(
     candidate_streak = 0
     last_non_default_at = time.time() * 1000
     start_time = time.time()
+    # gesture -> (chosen image, when it was last on screen), so a gesture
+    # flickering out and back keeps its image instead of re-rolling
+    meme_choice = {}
+
+    def pick_meme(gesture, now):
+        img, last_seen = meme_choice.get(gesture, (None, None))
+        if img is None or now - last_seen > MEME_REROLL_MS:
+            img = random.choice(memes[gesture])
+        meme_choice[gesture] = (img, now)
+        return img
 
     while not stop_event.is_set():
         frame = shared_frame.get()
@@ -639,13 +675,16 @@ def detection_loop(
             candidate_gesture = gesture
             candidate_streak = 1
 
-        if candidate_streak >= STABLE_FRAMES_REQUIRED and gesture != current_gesture:
+        # sticky once committed: cheap to adopt a gesture from rest, but a
+        # gesture already on screen takes noticeably longer to displace
+        needed = STABLE_FRAMES_REQUIRED if current_gesture == "default" else STABLE_FRAMES_TO_LEAVE
+        if candidate_streak >= needed and gesture != current_gesture:
             current_gesture = gesture
             if gesture in VIDEO_GESTURES:
                 if gesture == "spinCat":
                     memes["_spin_restart"] = True
             elif gesture in memes:
-                memes["_current"] = random.choice(memes[gesture])
+                memes["_current"] = pick_meme(gesture, now)
             # else: gesture is wired up but its artwork isn't in memes/ yet
             # (load_memes said so at startup). Still switch to it so the
             # readout names it - that's what makes the detection tunable
@@ -656,7 +695,7 @@ def detection_loop(
             last_non_default_at = now
         elif now - last_non_default_at > DEFAULT_FALLBACK_MS and current_gesture != "default":
             current_gesture = "default"
-            memes["_current"] = random.choice(memes["default"])
+            memes["_current"] = pick_meme("default", now)
 
         shared_detection.set(hand_result, current_gesture)
 

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -440,21 +440,24 @@ def get_screen_size():
         return 1440, 900
 
 
-# The Meme window is a plain autosizing cv2 window, so its size follows
-# whatever image we hand it - and since a window keeps its top-left corner
-# fixed, every meme with a different width made the window grow rightward.
-# Rather than chasing that by moving the window every frame (which fights
-# the user dragging it), draw every meme onto a canvas of one constant
-# size: the window is then created once at that size and never resizes at
-# all. The canvas is sized to the widest meme so nothing is ever cropped,
-# and narrower memes are centered in it.
-def paste_centered(img, canvas_w, canvas_h):
-    scale = min(canvas_w / img.shape[1], canvas_h / img.shape[0])
-    w, h = max(1, int(img.shape[1] * scale)), max(1, int(img.shape[0] * scale))
-    canvas = np.zeros((canvas_h, canvas_w, 3), dtype=img.dtype)
-    x, y = (canvas_w - w) // 2, (canvas_h - h) // 2
-    canvas[y:y + h, x:x + w] = cv2.resize(img, (w, h))
-    return canvas
+# Memes are shown at their own aspect ratio - never padded, never stretched,
+# so there are no letterbox bars. The Meme window autosizes to whatever it's
+# given, so it does change width from meme to meme, but the layout reserves
+# a box to its right big enough for the widest one, so that growth always
+# lands in empty reserved space rather than off screen or over the Camera
+# window. Since the window is never moved after placement, dragging works.
+#
+# Normally a meme is drawn at the shared display height. The one exception
+# is the spin video, which is far wider than any still meme - letting it
+# drive the reserved width would shrink the shared height (and so the cam)
+# for the whole session just for the rare moments it plays. Instead the box
+# is sized for the still memes, and anything wider than the box (only the
+# video) is scaled down to the box width.
+def fit_meme(img, height, max_w):
+    w = max(1, int(img.shape[1] * height / img.shape[0]))
+    if w > max_w:
+        w, height = max_w, max(1, int(img.shape[0] * max_w / img.shape[1]))
+    return cv2.resize(img, (w, height))
 
 
 # The web version stays smooth under load because the <video> tag renders on
@@ -586,10 +589,13 @@ def main():
     )
 
     memes = load_memes()
-    # widest aspect ratio of any meme - the fixed canvas is sized to this so
-    # even the widest one fits without being cropped or shrunk. Computed
-    # before the bookkeeping keys below are added, while every value is
-    # still a list of images.
+    # widest aspect ratio among the still memes - the reserved box is sized
+    # to this, so every still meme fits it at full height. The spin video is
+    # deliberately excluded: it's much wider than any of these, and letting
+    # it set the box would cost height (and cam size) all session long for
+    # the rare moments it plays; it gets scaled down to the box instead.
+    # Computed before the bookkeeping keys below are added, while every
+    # value is still a list of images.
     widest_meme_aspect = max(img.shape[1] / img.shape[0] for imgs in memes.values() for img in imgs)
     memes["_current"] = random.choice(memes["default"])
     memes["_spin_restart"] = False
@@ -604,11 +610,6 @@ def main():
     spin_video_cap = cv2.VideoCapture(str(MEMES / GESTURE_MEMES["spinCat"][0]))
     if not spin_video_cap.isOpened():
         raise FileNotFoundError(f"missing meme file: {MEMES / GESTURE_MEMES['spinCat'][0]}")
-    # the spin video is a meme too, so it has to fit the canvas as well
-    spin_w = spin_video_cap.get(cv2.CAP_PROP_FRAME_WIDTH)
-    spin_h = spin_video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
-    if spin_w > 0 and spin_h > 0:
-        widest_meme_aspect = max(widest_meme_aspect, spin_w / spin_h)
 
     def next_spin_frame():
         ok, vframe = spin_video_cap.read()
@@ -661,22 +662,24 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
-        # Both windows are sized ONCE here and never resize again. Capture
-        # runs at 1280x720 for quality and detection accuracy, but that's
-        # far too wide to show next to a meme on a normal screen, so pick
-        # one shared display height that lets cam + widest meme sit side by
-        # side within the screen. Sizes are constant for the whole session,
-        # so neither window ever grows and both stay freely draggable.
+        # Capture runs at 1280x720 for quality and detection accuracy, but
+        # that's far too wide to show next to a meme on this screen, so
+        # both windows share one display height, picked once so that the
+        # cam and the widest meme fit side by side. The cam window is a
+        # fixed size for the session; the meme window varies in width with
+        # each meme (shown at its own aspect, so no bars), but the space
+        # reserved to its right fits the widest one, so it can never grow
+        # off screen or over the cam.
         first_frame = shared_frame.get()
         cam_aspect = first_frame.shape[1] / first_frame.shape[0]
         screen_w, screen_h = get_screen_size()
         LEFT, GAP, RIGHT, TOP, BOTTOM = 40, 40, 40, 80, 60
-        h = min(
+        display_h = min(
             screen_h - TOP - BOTTOM,
             int((screen_w - LEFT - GAP - RIGHT) / (cam_aspect + widest_meme_aspect)),
         )
-        cam_w, cam_h = int(cam_aspect * h), h
-        canvas_w, canvas_h = int(widest_meme_aspect * h), h
+        cam_w, cam_h = int(cam_aspect * display_h), display_h
+        meme_max_w = int(widest_meme_aspect * display_h)  # reserved box the meme can never exceed
 
         cv2.moveWindow("Camera", LEFT, TOP)
         cv2.moveWindow("Meme", LEFT + cam_w + GAP, TOP)
@@ -701,10 +704,8 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            # always the same canvas size, so the window never resizes and
-            # therefore never grows in any direction - and since we never
-            # move it, dragging it works normally
-            meme_view = paste_centered(meme_img, canvas_w, canvas_h)
+            # own aspect ratio, no bars; only the spin video hits max_w
+            meme_view = fit_meme(meme_img, display_h, meme_max_w)
 
             cv2.imshow("Camera", cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow("Meme", meme_view)

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -419,25 +419,10 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-# scale an image's own aspect ratio to the largest size that fits within a
-# box, without cropping or distorting it.
-def fit_within(img_w, img_h, box_w, box_h):
-    scale = min(box_w / img_w, box_h / img_h)
-    return max(1, int(img_w * scale)), max(1, int(img_h * scale))
-
-
-def get_screen_size():
-    """Query the actual display resolution (via a throwaway Tk root) so
-    windows can be sized/placed to fill the screen instead of guessing."""
-    try:
-        import tkinter as tk
-        root = tk.Tk()
-        root.withdraw()
-        w, h = root.winfo_screenwidth(), root.winfo_screenheight()
-        root.destroy()
-        return w, h
-    except Exception:
-        return 1440, 900
+def fit_to_height(img, height):
+    h, w = img.shape[:2]
+    scale = height / h
+    return cv2.resize(img, (int(w * scale), height))
 
 
 # The web version stays smooth under load because the <video> tag renders on
@@ -569,10 +554,6 @@ def main():
     )
 
     memes = load_memes()
-    # widest aspect ratio across every meme image, so the meme window can be
-    # given exactly enough room for the biggest one up front, instead of
-    # discovering mid-session that some meme doesn't fit
-    max_meme_aspect = max(img.shape[1] / img.shape[0] for imgs in memes.values() for img in imgs)
     memes["_current"] = random.choice(memes["default"])
     memes["_spin_restart"] = False
 
@@ -586,10 +567,6 @@ def main():
     spin_video_cap = cv2.VideoCapture(str(MEMES / GESTURE_MEMES["spinCat"][0]))
     if not spin_video_cap.isOpened():
         raise FileNotFoundError(f"missing meme file: {MEMES / GESTURE_MEMES['spinCat'][0]}")
-    spin_w = spin_video_cap.get(cv2.CAP_PROP_FRAME_WIDTH)
-    spin_h = spin_video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
-    if spin_w and spin_h:
-        max_meme_aspect = max(max_meme_aspect, spin_w / spin_h)
 
     def next_spin_frame():
         ok, vframe = spin_video_cap.read()
@@ -602,25 +579,18 @@ def main():
     if not cap.isOpened():
         raise RuntimeError("Could not open webcam (index 0)")
     # ask for a proper resolution and fps - an unconfigured VideoCapture
-    # often defaults to a low-res mode (this was the actual "quality" gap
-    # vs. the web version, which requests 640x480 but through getUserMedia's
-    # own negotiation that tends to pick a much better encode than
-    # AVFoundation's default). MJPG gives the camera more bandwidth
+    # often defaults to a low-res mode. MJPG gives the camera more bandwidth
     # headroom to hit both the resolution and the fps target.
-    # 4:3 instead of 16:9 - the cam window sits in a half-screen column,
-    # which is narrower than it is wide, so a 16:9 frame ends up short
-    # (looks small) once scaled to fit that column. 4:3 is much closer to
-    # the column's own aspect ratio, so it scales up bigger.
     cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 960)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
     cap.set(cv2.CAP_PROP_FPS, 30)
     cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)  # always grab the newest frame, not a queued stale one
 
-    CAM_WINDOW, MEME_WINDOW = "Camera", "Meme"
-    screen_w, screen_h = get_screen_size()
-    TOP_MARGIN = 60  # menu bar + window title bar, so windows don't get placed under them
-    avail_h = screen_h - TOP_MARGIN
+    cv2.namedWindow("Camera")
+    cv2.namedWindow("Meme")
+    cv2.moveWindow("Camera", 40, 80)
+    cv2.moveWindow("Meme", 720, 80)
 
     state = GestureState()
     shared_frame = SharedFrame()
@@ -646,27 +616,9 @@ def main():
     det_thread.start()
 
     try:
-        # wait for the first camera frame so we know its native aspect ratio
-        # before sizing the window (and so the window doesn't flash empty)
+        # wait for the first camera frame so the window doesn't flash empty
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
-
-        # reserve just enough width for the biggest meme at full height, plus
-        # a small gap so the two windows don't sit glued together - the cam
-        # gets everything else. Sized once, never touched again: no meme,
-        # however big, ever needs more room than this, so the cam never has
-        # to resize or get overlapped.
-        WINDOW_GAP = 24
-        meme_max_w = int(max_meme_aspect * avail_h)
-        first_frame = shared_frame.get()
-        cam_w, cam_h = fit_within(
-            first_frame.shape[1], first_frame.shape[0], screen_w - meme_max_w - WINDOW_GAP, avail_h
-        )
-
-        cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
-        cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
-        cv2.moveWindow(CAM_WINDOW, 0, TOP_MARGIN)  # left edge pinned to screen's left edge
-        cv2.namedWindow(MEME_WINDOW, cv2.WINDOW_NORMAL)
 
         while not stop_event.is_set():
             frame = shared_frame.get()
@@ -684,22 +636,16 @@ def main():
                     spin_video_cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
                     memes["_spin_restart"] = False
                 vframe = next_spin_frame()
-                meme_img = vframe if vframe is not None else memes["_current"]
+                meme_view = (
+                    fit_to_height(vframe, frame.shape[0])
+                    if vframe is not None
+                    else fit_to_height(memes["_current"], frame.shape[0])
+                )
             else:
-                meme_img = memes["_current"]
+                meme_view = fit_to_height(memes["_current"], frame.shape[0])
 
-            meme_w, meme_h = fit_within(meme_img.shape[1], meme_img.shape[0], meme_max_w, avail_h)
-
-            cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
-            cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))
-            # macOS/Cocoa backend sometimes ignores resizeWindow if it's not
-            # re-applied after imshow, so pin the size every frame. Only the
-            # meme window is resized here - the cam window is fixed above.
-            cv2.resizeWindow(MEME_WINDOW, meme_w, meme_h)
-            # anchor the Meme window's RIGHT edge to the screen's right edge,
-            # so as the meme's width changes the window grows/shrinks
-            # leftward (into its own leftover space) instead of rightward
-            cv2.moveWindow(MEME_WINDOW, screen_w - meme_w, TOP_MARGIN)
+            cv2.imshow("Camera", frame)
+            cv2.imshow("Meme", meme_view)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -644,10 +644,10 @@ def main():
             time.sleep(0.01)
 
         # cam window is sized ONCE here, to its own aspect ratio maximized
-        # within its half of the screen, and never touched again - nothing
-        # the meme does (including its own size) can resize the cam.
+        # within 2/3 of the screen's width, and never touched again -
+        # nothing the meme does (including its own size) can resize the cam.
         first_frame = shared_frame.get()
-        cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w // 2, avail_h)
+        cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w * 2 // 3, avail_h)
         meme_max_w = screen_w - cam_w  # whatever's left over, meme fits within - never touches the cam
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -419,20 +419,11 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-# Give the cam and meme windows a fair, uncropped share of the screen: both
-# get the SAME height, and each one's width follows from its own aspect
-# ratio (a wide 16:9 cam naturally needs more width than a near-square meme
-# to reach the same height). A fixed half-and-half column split doesn't work
-# here - the cam is much wider than most meme images, so at equal width the
-# cam would end up much shorter (looking tiny) while the meme fills the
-# column (looking huge). Use the full available height if both fit
-# side-by-side at that height; otherwise shrink both together until they do.
-def split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h):
-    h = avail_h
-    if (cam_aspect + meme_aspect) * h > screen_w:
-        h = screen_w / (cam_aspect + meme_aspect)
-    h = int(h)
-    return max(1, int(cam_aspect * h)), h, max(1, int(meme_aspect * h)), h
+# scale an image's own aspect ratio to the largest size that fits within a
+# box, without cropping or distorting it.
+def fit_within(img_w, img_h, box_w, box_h):
+    scale = min(box_w / img_w, box_h / img_h)
+    return max(1, int(img_w * scale)), max(1, int(img_h * scale))
 
 
 def get_screen_size():
@@ -648,11 +639,21 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
+        # cam window is sized ONCE here, to its own aspect ratio maximized
+        # across the whole screen, and never touched again - the meme window
+        # never affects it.
         first_frame = shared_frame.get()
-        cam_aspect = first_frame.shape[1] / first_frame.shape[0]
+        cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w, avail_h)
+        cam_x, cam_y = (screen_w - cam_w) // 2, TOP_MARGIN + (avail_h - cam_h) // 2
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
-        cv2.moveWindow(CAM_WINDOW, 0, TOP_MARGIN)  # left edge pinned to screen's left edge
+        cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
+        cv2.moveWindow(CAM_WINDOW, cam_x, cam_y)
+
+        # meme window floats on top of the cam window, centered over it,
+        # capped to a fraction of its size so it reads as an overlay rather
+        # than competing with the cam for screen space.
+        MEME_MAX_W, MEME_MAX_H = int(cam_w * 0.5), int(cam_h * 0.6)
         cv2.namedWindow(MEME_WINDOW, cv2.WINDOW_NORMAL)
 
         while not stop_event.is_set():
@@ -675,19 +676,17 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            meme_aspect = meme_img.shape[1] / meme_img.shape[0]
-            cam_w, cam_h, meme_w, meme_h = split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h)
+            meme_w, meme_h = fit_within(meme_img.shape[1], meme_img.shape[0], MEME_MAX_W, MEME_MAX_H)
 
             cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))
             # macOS/Cocoa backend sometimes ignores resizeWindow if it's not
-            # re-applied after imshow, so pin the size every frame
-            cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
+            # re-applied after imshow, so pin the size every frame. Only the
+            # meme window is resized here - the cam window is fixed above.
             cv2.resizeWindow(MEME_WINDOW, meme_w, meme_h)
-            # anchor the Meme window's RIGHT edge to the screen's right edge,
-            # so as the meme's width changes the window grows/shrinks
-            # leftward (into the screen) instead of rightward (off it)
-            cv2.moveWindow(MEME_WINDOW, screen_w - meme_w, TOP_MARGIN)
+            # keep it centered over the cam window as its size changes, so
+            # it grows/shrinks symmetrically instead of drifting to an edge
+            cv2.moveWindow(MEME_WINDOW, cam_x + (cam_w - meme_w) // 2, cam_y + (cam_h - meme_h) // 2)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -30,6 +30,7 @@ Press q or ESC to quit.
 
 import math
 import random
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -420,14 +421,20 @@ def draw_landmarks(frame, hand_result):
 
 
 def get_screen_size():
-    """Actual display resolution, via a throwaway Tk root, so the two
-    windows can be sized to fit on screen instead of guessing."""
+    """Actual (logical) display resolution, so the two windows can be sized
+    to fit on screen instead of guessing.
+
+    Asks the window server through osascript rather than tkinter: Tk 8.6
+    aborts the whole process with an uncatchable ObjC NSException
+    (-[NSApplication macOSVersion]) on recent macOS, and osascript runs in
+    a subprocess, so any failure there can't take this process down.
+    """
     try:
-        import tkinter as tk
-        root = tk.Tk()
-        root.withdraw()
-        w, h = root.winfo_screenwidth(), root.winfo_screenheight()
-        root.destroy()
+        out = subprocess.run(
+            ["osascript", "-e", "tell application \"Finder\" to get bounds of window of desktop"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout
+        _, _, w, h = (int(v.strip()) for v in out.split(","))
         return w, h
     except Exception:
         return 1440, 900

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -620,13 +620,6 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
-        # right edge of the Meme window, pinned at its starting position -
-        # as the meme's width changes each frame, we re-move the window so
-        # this edge stays put and the window grows/shrinks leftward instead
-        # of rightward off screen
-        first_frame = shared_frame.get()
-        meme_right_x = 720 + fit_to_height(memes["_current"], first_frame.shape[0]).shape[1]
-
         while not stop_event.is_set():
             frame = shared_frame.get()
             if frame is None:
@@ -653,7 +646,6 @@ def main():
 
             cv2.imshow("Camera", frame)
             cv2.imshow("Meme", meme_view)
-            cv2.moveWindow("Meme", meme_right_x - meme_view.shape[1], 80)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -648,6 +648,7 @@ def main():
         # nothing the meme does (including its own size) can resize the cam.
         first_frame = shared_frame.get()
         cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w * 2 // 3, avail_h)
+        meme_max_w = screen_w - cam_w  # whatever's left over, meme fits within - never touches the cam
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
         cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
@@ -674,13 +675,7 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            # always fill the full available height - never shrink it to
-            # stay within the leftover width. If it needs more width than
-            # that, it overlaps the cam window instead (right-anchored, so
-            # it grows leftward over the cam rather than off the screen).
-            meme_aspect = meme_img.shape[1] / meme_img.shape[0]
-            meme_h = avail_h
-            meme_w = max(1, int(meme_aspect * meme_h))
+            meme_w, meme_h = fit_within(meme_img.shape[1], meme_img.shape[0], meme_max_w, avail_h)
 
             cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -419,20 +419,11 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-# Give the cam and meme windows a fair, uncropped share of the screen: both
-# get the SAME height, and each one's width follows from its own aspect
-# ratio (a wide 16:9 cam naturally needs more width than a near-square meme
-# to reach the same height). A fixed half-and-half column split doesn't work
-# here - the cam is much wider than most meme images, so at equal width the
-# cam would end up much shorter (looking tiny) while the meme fills the
-# column (looking huge). Use the full available height if both fit
-# side-by-side at that height; otherwise shrink both together until they do.
-def split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h):
-    h = avail_h
-    if (cam_aspect + meme_aspect) * h > screen_w:
-        h = screen_w / (cam_aspect + meme_aspect)
-    h = int(h)
-    return max(1, int(cam_aspect * h)), h, max(1, int(meme_aspect * h)), h
+# scale an image's own aspect ratio to the largest size that fits within a
+# box, without cropping or distorting it.
+def fit_within(img_w, img_h, box_w, box_h):
+    scale = min(box_w / img_w, box_h / img_h)
+    return max(1, int(img_w * scale)), max(1, int(img_h * scale))
 
 
 def get_screen_size():
@@ -648,10 +639,15 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
+        # cam window is sized ONCE here, to its own aspect ratio maximized
+        # within its half of the screen, and never touched again - nothing
+        # the meme does (including its own size) can resize the cam.
         first_frame = shared_frame.get()
-        cam_aspect = first_frame.shape[1] / first_frame.shape[0]
+        cam_w, cam_h = fit_within(first_frame.shape[1], first_frame.shape[0], screen_w // 2, avail_h)
+        meme_max_w = screen_w - cam_w  # whatever's left over, meme fits within - never touches the cam
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
+        cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
         cv2.moveWindow(CAM_WINDOW, 0, TOP_MARGIN)  # left edge pinned to screen's left edge
         cv2.namedWindow(MEME_WINDOW, cv2.WINDOW_NORMAL)
 
@@ -675,18 +671,17 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            meme_aspect = meme_img.shape[1] / meme_img.shape[0]
-            cam_w, cam_h, meme_w, meme_h = split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h)
+            meme_w, meme_h = fit_within(meme_img.shape[1], meme_img.shape[0], meme_max_w, avail_h)
 
             cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))
             # macOS/Cocoa backend sometimes ignores resizeWindow if it's not
-            # re-applied after imshow, so pin the size every frame
-            cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
+            # re-applied after imshow, so pin the size every frame. Only the
+            # meme window is resized here - the cam window is fixed above.
             cv2.resizeWindow(MEME_WINDOW, meme_w, meme_h)
             # anchor the Meme window's RIGHT edge to the screen's right edge,
             # so as the meme's width changes the window grows/shrinks
-            # leftward (into the screen) instead of rightward (off it)
+            # leftward (into its own leftover space) instead of rightward
             cv2.moveWindow(MEME_WINDOW, screen_w - meme_w, TOP_MARGIN)
 
             # no delay beyond what's needed to pump the GUI event loop - the

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -19,11 +19,18 @@ Gestures:
   hand stretched out, palm facing camera (open hand)       -> memes/hand stretched out, palm facing up .jpg
   side eye (head turned to the side)                       -> memes/side eye cat.jpg
   spin cat (spinning fast in your chair)                   -> memes/spin cat.mov (plays as a video)
+  screaming (mouth wide open)                              -> memes/screaming cat.jpg
+  huh? (head tilted sideways)                              -> memes/huh cat.jpg
 
-The Camera window shows a live debug readout (head yaw, and optical-flow
-magnitude/coherence, vs. their trigger thresholds) in the top-left corner so
-side-eye and spin can both be tuned by eye - see SIDE_EYE_YAW_DEG and
-SPIN_FLOW_SCORE_THRESHOLD below.
+A gesture whose meme file isn't in memes/ yet is reported at startup and
+simply never fires, so new gestures can be wired up before their artwork
+exists.
+
+The Camera window shows a compact live readout in the top-left corner -
+each line is "value/threshold" for the signals that drive a gesture (head
+yaw, head roll, mouth openness, and optical-flow magnitude/fraction), so
+they can all be tuned by eye. See SIDE_EYE_YAW_DEG, HUH_ROLL_DEG,
+SCREAM_MOUTH_OPEN and the SPIN_* constants below.
 
 Press q or ESC to quit.
 """
@@ -64,6 +71,8 @@ GESTURE_MEMES = {
     "handStretchedOut": ["hand stretched out, palm facing up .jpg"],
     "sideEyeCat": ["side eye cat.jpg"],
     "spinCat": ["spin cat.mov"],
+    "screamingCat": ["screaming cat.jpg"],
+    "huhCat": ["huh cat.jpg"],
 }
 
 # gestures whose meme is a video, not a still image
@@ -78,6 +87,20 @@ FACE_STALE_MS = 1200
 # side-eye look. Watch the live "yaw" readout in the Camera window while
 # turning your head to find the right value for you.
 SIDE_EYE_YAW_DEG = 15.0
+
+# how far the head has to tilt sideways (roll, degrees, same head-pose
+# estimate) for the "huh?" head-tilt look. Set well above SIDE_EYE_YAW_DEG's
+# neighbourhood of casual movement - a deliberate tilt is a big, obvious
+# motion, and a small roll is just how people naturally hold their head.
+# Watch the live "roll" readout while tilting to tune it.
+HUH_ROLL_DEG = 18.0
+
+# how far open the mouth has to be to count as a scream. Measured as
+# lip-gap over face width, so it doesn't change with distance from the
+# camera: resting mouth sits near 0, talking hovers well under 0.35, and a
+# deliberate wide-open scream goes past it. Watch the live "mouth" readout
+# to tune.
+SCREAM_MOUTH_OPEN = 0.35
 
 # spin detection: full-frame optical flow, downsized for speed. We compute
 # magnitude (how much of the frame moved, on average) each frame; coherence
@@ -157,17 +180,21 @@ def finger_extended(pts, mcp, pip, tip):
     return angle_deg(v1, v2) < 45
 
 
-def yaw_from_transform_matrix(matrix):
-    """Extract the head's left/right turn angle (yaw, degrees) from
-    MediaPipe's facial transformation matrix - its own estimate of head
-    pose, far more robust than trying to infer turn from landmark
-    distances."""
+def yaw_roll_from_transform_matrix(matrix):
+    """Extract the head's left/right turn (yaw) and sideways tilt (roll),
+    in degrees, from MediaPipe's facial transformation matrix - its own
+    estimate of head pose, far more robust than trying to infer either
+    from landmark distances.
+
+    Yaw drives side-eye; roll drives the head-tilt "huh?" look.
+    """
     r = np.asarray(matrix)[:3, :3]
     sy = math.sqrt(r[0, 0] ** 2 + r[1, 0] ** 2)
     if sy < 1e-6:
-        return 0.0
+        return 0.0, 0.0
     yaw = math.atan2(-r[2, 0], sy)
-    return math.degrees(yaw)
+    roll = math.atan2(r[1, 0], r[0, 0])
+    return math.degrees(yaw), math.degrees(roll)
 
 
 def classify_hand(landmarks):
@@ -238,9 +265,11 @@ def frame_flow_signal(frame, prev_small_gray):
 
 class GestureState:
     def __init__(self):
-        self.last_face = None  # (mouth_center, face_width, mouth_open, yaw_deg, t)
+        self.last_face = None  # (mouth_center, face_width, mouth_open, yaw_deg, roll_deg, t)
         self.face_seen_this_frame = False
         self.last_yaw_debug = 0.0
+        self.last_roll_debug = 0.0
+        self.last_mouth_open_debug = 0.0
         self.flow_history = []  # [(t, magnitude), ...] trailing samples, for the fraction-above trigger
         self.flow_peak_history = []  # [(t, score), ...] longer trailing window, for the readable peak display
         self.last_flow_magnitude_debug = 0.0
@@ -288,27 +317,41 @@ class GestureState:
             face_width = dist(right_cheek, left_cheek)
             mouth_open = dist(upper_lip, lower_lip) / face_width
 
-            yaw_deg = 0.0
+            yaw_deg = roll_deg = 0.0
             if face_result.facial_transformation_matrixes:
-                yaw_deg = yaw_from_transform_matrix(face_result.facial_transformation_matrixes[0])
+                yaw_deg, roll_deg = yaw_roll_from_transform_matrix(
+                    face_result.facial_transformation_matrixes[0]
+                )
 
-            self.last_face = (mouth_center, face_width, mouth_open, yaw_deg, now)
+            self.last_face = (mouth_center, face_width, mouth_open, yaw_deg, roll_deg, now)
             self.last_yaw_debug = yaw_deg
+            self.last_roll_debug = roll_deg
+            self.last_mouth_open_debug = mouth_open
         self.face_seen_this_frame = saw_face
 
     def decide(self, hand_result):
         now = time.time() * 1000
-        face_is_fresh = self.last_face is not None and now - self.last_face[4] < FACE_STALE_MS
+        face_is_fresh = self.last_face is not None and now - self.last_face[5] < FACE_STALE_MS
 
         # spinning in the chair beats everything else, hands included.
         if self.is_spinning(now):
             return "spinCat"
 
+        # a wide-open mouth is a deliberate, unmistakable pose, so it wins
+        # over any hand shape - screaming with your hands up is still a
+        # scream. Checked before the no-hands branch for that reason.
+        if face_is_fresh and self.last_face[2] > SCREAM_MOUTH_OPEN:
+            return "screamingCat"
+
         if not hand_result.hand_landmarks:
-            # no hands: side-eye is a face-only pose (head turned, no
-            # particular hand shape needed).
+            # no hands: these are face-only poses (head turned or tilted, no
+            # particular hand shape needed). Side-eye is checked first
+            # because a turned head reads as the stronger intent when both
+            # thresholds happen to trip.
             if face_is_fresh and abs(self.last_face[3]) > SIDE_EYE_YAW_DEG:
                 return "sideEyeCat"
+            if face_is_fresh and abs(self.last_face[4]) > HUH_ROLL_DEG:
+                return "huhCat"
             return "default"
 
         hands = [classify_hand(lm) for lm in hand_result.hand_landmarks]
@@ -321,7 +364,7 @@ class GestureState:
                     return "twoFingersTogether"
 
             if face_is_fresh:
-                mouth_center, face_width, _, _, _ = self.last_face
+                mouth_center, face_width, _, _, _, _ = self.last_face
                 near_face = all(
                     dist(h["palmCenter"], mouth_center) / face_width < 2.2 for h in hands
                 )
@@ -347,7 +390,7 @@ class GestureState:
         # gets swallowed by the "any hand near the face" check.
         if h["indexUp"] and not h["middleUp"] and not h["ringUp"] and not h["pinkyUp"]:
             if face_is_fresh:
-                mouth_center, face_width, _, _, _ = self.last_face
+                mouth_center, face_width, _, _, _, _ = self.last_face
                 d = dist(h["indexTip"], mouth_center) / face_width
                 if d < 0.55:
                     return "shhh"
@@ -358,7 +401,7 @@ class GestureState:
         # lost the face (strong evidence of a real occlusion); tighter if
         # it's still partially tracking through the fingers.
         if face_is_fresh:
-            mouth_center, face_width, _, _, _ = self.last_face
+            mouth_center, face_width, _, _, _, _ = self.last_face
             d = dist(h["palmCenter"], mouth_center) / face_width
             threshold = (
                 HAND_COVER_FACE_DIST_FACE_LOST
@@ -373,14 +416,24 @@ class GestureState:
             return "handStretchedOut"
 
         # hands are up but not making a specific shape - still allow a
-        # strong side-eye read to win over an ambiguous hand pose.
+        # strong side-eye or head-tilt read to win over an ambiguous pose.
         if face_is_fresh and abs(self.last_face[3]) > SIDE_EYE_YAW_DEG:
             return "sideEyeCat"
+        if face_is_fresh and abs(self.last_face[4]) > HUH_ROLL_DEG:
+            return "huhCat"
 
         return "default"
 
 
 def load_memes():
+    """Load every meme image, keyed by gesture.
+
+    A gesture whose image files are all missing is skipped rather than
+    fatal, and simply never fires (decide() falls back to default for it) -
+    that way a gesture can be wired up here before its artwork exists
+    without taking the whole app down. Anything missing is reported on
+    stdout so it doesn't fail silently.
+    """
     cache = {}
     for gesture, files in GESTURE_MEMES.items():
         if gesture in VIDEO_GESTURES:
@@ -390,39 +443,39 @@ def load_memes():
         for name in files:
             img = cv2.imread(str(MEMES / name))
             if img is None:
-                raise FileNotFoundError(f"missing meme file: {MEMES / name}")
+                print(f"[meme missing] {MEMES / name} - '{gesture}' disabled until it's added")
+                continue
             imgs.append(img)
-        cache[gesture] = imgs
+        if imgs:
+            cache[gesture] = imgs
     return cache
 
 
 def draw_debug_hud(frame, state, gesture):
+    # compact: value and its trigger threshold per line, no prose
     lines = [
-        f"gesture: {gesture}",
-        f"yaw: {state.last_yaw_debug:+.1f} deg  (side-eye thr +/-{SIDE_EYE_YAW_DEG:.1f})",
-        f"flow mag: {state.last_flow_magnitude_debug:.2f}  (thr {SPIN_MAG_THRESHOLD:.2f})",
-        f"spin fraction (2.2s window): {state.last_flow_fraction_debug:.2f}  (thr {SPIN_FRACTION_REQUIRED:.2f})",
-        f"peak score (last 2s): {state.last_flow_peak_debug:.2f}  <- read this AFTER you stop spinning",
+        f"{gesture}",
+        f"yaw  {state.last_yaw_debug:+5.1f}/{SIDE_EYE_YAW_DEG:.0f}",
+        f"roll {state.last_roll_debug:+5.1f}/{HUH_ROLL_DEG:.0f}",
+        f"mouth {state.last_mouth_open_debug:.2f}/{SCREAM_MOUTH_OPEN:.2f}",
+        f"flow {state.last_flow_magnitude_debug:.2f}/{SPIN_MAG_THRESHOLD:.2f}",
+        f"spin {state.last_flow_fraction_debug:.2f}/{SPIN_FRACTION_REQUIRED:.2f}"
+        f"  pk {state.last_flow_peak_debug:.2f}",
     ]
 
-    font, scale, thick, outline = cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1, 3
-    pad, line_h = 8, 20
-    # measure with the outline thickness, not the fill thickness - the dark
-    # outline is what actually sets how far the text reaches - and allow for
-    # it overhanging the reported advance width on both sides
-    text_w = max(cv2.getTextSize(l, font, scale, outline)[0][0] for l in lines) + outline * 2
+    font, scale, thick = cv2.FONT_HERSHEY_SIMPLEX, 0.38, 1
+    pad, line_h = 6, 14
 
-    # dark panel behind the text - the readout used to sit directly on the
-    # camera image, where thin green glyphs washed out over bright or busy
-    # areas of the frame
-    panel_w = min(frame.shape[1], pad * 2 + text_w)
-    panel_h = min(frame.shape[0], pad * 2 + line_h * len(lines))
-    panel = frame[0:panel_h, 0:panel_w]
-    cv2.addWeighted(panel, 0.15, np.zeros_like(panel), 0.85, 0, panel)
-
+    # Outline drawn as the same text, same thickness, nudged one pixel in
+    # each direction. Drawing it once at a heavier thickness instead (the
+    # usual trick) doesn't work here: in OpenCV thickness also widens the
+    # per-glyph advance, so a thickness-3 pass ends up to ~30px wider than
+    # the thickness-1 fill on these lines, and the two drift apart into
+    # what looks like a second, offset copy of the readout.
     for i, line in enumerate(lines):
-        y = pad + line_h * i + 14
-        cv2.putText(frame, line, (pad, y), font, scale, (0, 0, 0), 3, cv2.LINE_AA)
+        y = pad + line_h * i + 10
+        for dx, dy in ((-1, -1), (1, -1), (-1, 1), (1, 1), (0, -1), (0, 1), (-1, 0), (1, 0)):
+            cv2.putText(frame, line, (pad + dx, y + dy), font, scale, (0, 0, 0), thick, cv2.LINE_AA)
         cv2.putText(frame, line, (pad, y), font, scale, (0, 255, 120), thick, cv2.LINE_AA)
 
 
@@ -572,11 +625,17 @@ def detection_loop(
             candidate_streak = 1
 
         if candidate_streak >= STABLE_FRAMES_REQUIRED and gesture != current_gesture:
-            current_gesture = gesture
-            if gesture not in VIDEO_GESTURES:
+            if gesture in VIDEO_GESTURES:
+                current_gesture = gesture
+                if gesture == "spinCat":
+                    memes["_spin_restart"] = True
+            elif gesture in memes:
+                current_gesture = gesture
                 memes["_current"] = random.choice(memes[gesture])
-            elif gesture == "spinCat":
-                memes["_spin_restart"] = True
+            else:
+                # gesture is wired up but its artwork isn't in memes/ yet
+                # (load_memes reported it) - stay on whatever is showing
+                gesture = current_gesture
 
         if gesture != "default":
             last_non_default_at = now

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -96,11 +96,12 @@ SIDE_EYE_YAW_DEG = 15.0
 HUH_ROLL_DEG = 18.0
 
 # how far open the mouth has to be to count as a scream. Measured as
-# lip-gap over face width, so it doesn't change with distance from the
-# camera: resting mouth sits near 0, talking hovers well under 0.35, and a
-# deliberate wide-open scream goes past it. Watch the live "mouth" readout
-# to tune.
-SCREAM_MOUTH_OPEN = 0.35
+# lip-gap over face height (chin to forehead), so it changes neither with
+# distance from the camera nor with the capture aspect ratio: a closed
+# mouth sits near 0, talking peaks around 0.08, and a deliberate
+# wide-open scream runs past 0.15. Watch the live "mouth" readout in the
+# Camera window to tune it for your face.
+SCREAM_MOUTH_OPEN = 0.15
 
 # spin detection: full-frame optical flow, downsized for speed. We compute
 # magnitude (how much of the frame moved, on average) each frame; coherence
@@ -313,9 +314,16 @@ class GestureState:
             f = face_result.face_landmarks[0]
             upper_lip, lower_lip = p3(f[13]), p3(f[14])
             right_cheek, left_cheek = p3(f[234]), p3(f[454])
+            forehead, chin = p3(f[10]), p3(f[152])
             mouth_center = (upper_lip + lower_lip) / 2
             face_width = dist(right_cheek, left_cheek)
-            mouth_open = dist(upper_lip, lower_lip) / face_width
+            # Normalize the lip gap against face HEIGHT, not width. Landmark
+            # x and y are normalized against the frame's width and height
+            # separately, so a vertical measurement over a horizontal one
+            # silently scales with the capture aspect ratio - the same
+            # scream would read differently at 16:9 than at 4:3. Chin to
+            # forehead is vertical like the lip gap, so that cancels out.
+            mouth_open = dist(upper_lip, lower_lip) / max(dist(forehead, chin), 1e-6)
 
             yaw_deg = roll_deg = 0.0
             if face_result.facial_transformation_matrixes:
@@ -625,17 +633,17 @@ def detection_loop(
             candidate_streak = 1
 
         if candidate_streak >= STABLE_FRAMES_REQUIRED and gesture != current_gesture:
+            current_gesture = gesture
             if gesture in VIDEO_GESTURES:
-                current_gesture = gesture
                 if gesture == "spinCat":
                     memes["_spin_restart"] = True
             elif gesture in memes:
-                current_gesture = gesture
                 memes["_current"] = random.choice(memes[gesture])
-            else:
-                # gesture is wired up but its artwork isn't in memes/ yet
-                # (load_memes reported it) - stay on whatever is showing
-                gesture = current_gesture
+            # else: gesture is wired up but its artwork isn't in memes/ yet
+            # (load_memes said so at startup). Still switch to it so the
+            # readout names it - that's what makes the detection tunable
+            # before the art exists - and leave the meme window showing
+            # whatever it had.
 
         if gesture != "default":
             last_non_default_at = now

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -419,12 +419,20 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-# size a window to its own content's aspect ratio, maximized within a given
-# box, instead of forcing content into a fixed-aspect box (which either
-# crops part of the picture off or wastes space with letterbox bars).
-def fit_dims(img_w, img_h, box_w, box_h):
-    scale = min(box_w / img_w, box_h / img_h)
-    return max(1, int(img_w * scale)), max(1, int(img_h * scale))
+# Give the cam and meme windows a fair, uncropped share of the screen: both
+# get the SAME height, and each one's width follows from its own aspect
+# ratio (a wide 16:9 cam naturally needs more width than a near-square meme
+# to reach the same height). A fixed half-and-half column split doesn't work
+# here - the cam is much wider than most meme images, so at equal width the
+# cam would end up much shorter (looking tiny) while the meme fills the
+# column (looking huge). Use the full available height if both fit
+# side-by-side at that height; otherwise shrink both together until they do.
+def split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h):
+    h = avail_h
+    if (cam_aspect + meme_aspect) * h > screen_w:
+        h = screen_w / (cam_aspect + meme_aspect)
+    h = int(h)
+    return max(1, int(cam_aspect * h)), h, max(1, int(meme_aspect * h)), h
 
 
 def get_screen_size():
@@ -609,7 +617,7 @@ def main():
     CAM_WINDOW, MEME_WINDOW = "Camera", "Meme"
     screen_w, screen_h = get_screen_size()
     TOP_MARGIN = 60  # menu bar + window title bar, so windows don't get placed under them
-    avail_w, avail_h = screen_w // 2, screen_h - TOP_MARGIN
+    avail_h = screen_h - TOP_MARGIN
 
     state = GestureState()
     shared_frame = SharedFrame()
@@ -641,12 +649,10 @@ def main():
             time.sleep(0.01)
 
         first_frame = shared_frame.get()
-        cam_w, cam_h = fit_dims(first_frame.shape[1], first_frame.shape[0], avail_w, avail_h)
+        cam_aspect = first_frame.shape[1] / first_frame.shape[0]
 
         cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
-        cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
         cv2.moveWindow(CAM_WINDOW, 0, TOP_MARGIN)  # left edge pinned to screen's left edge
-
         cv2.namedWindow(MEME_WINDOW, cv2.WINDOW_NORMAL)
 
         while not stop_event.is_set():
@@ -669,12 +675,14 @@ def main():
             else:
                 meme_img = memes["_current"]
 
-            meme_w, meme_h = fit_dims(meme_img.shape[1], meme_img.shape[0], avail_w, avail_h)
+            meme_aspect = meme_img.shape[1] / meme_img.shape[0]
+            cam_w, cam_h, meme_w, meme_h = split_by_aspect(cam_aspect, meme_aspect, screen_w, avail_h)
 
             cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))
             # macOS/Cocoa backend sometimes ignores resizeWindow if it's not
             # re-applied after imshow, so pin the size every frame
+            cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
             cv2.resizeWindow(MEME_WINDOW, meme_w, meme_h)
             # anchor the Meme window's RIGHT edge to the screen's right edge,
             # so as the meme's width changes the window grows/shrinks

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -673,13 +673,21 @@ def main():
         first_frame = shared_frame.get()
         cam_aspect = first_frame.shape[1] / first_frame.shape[0]
         screen_w, screen_h = get_screen_size()
-        LEFT, GAP, RIGHT, TOP, BOTTOM = 40, 40, 40, 80, 60
+        LEFT, GAP, RIGHT, TOP, BOTTOM = 12, 16, 12, 60, 40
+        # SIZE_SCALE pushes past the height at which cam and widest meme both
+        # fit at full size. The leftover width below absorbs it: the cam gets
+        # the full increase, and the widest memes give back a few pixels of
+        # width (scaled by fit_meme) rather than the whole layout staying
+        # small. Trimmed margins above supply most of the extra room.
+        SIZE_SCALE = 1.04
         display_h = min(
             screen_h - TOP - BOTTOM,
-            int((screen_w - LEFT - GAP - RIGHT) / (cam_aspect + widest_meme_aspect)),
+            int(SIZE_SCALE * (screen_w - LEFT - GAP - RIGHT) / (cam_aspect + widest_meme_aspect)),
         )
         cam_w, cam_h = int(cam_aspect * display_h), display_h
-        meme_max_w = int(widest_meme_aspect * display_h)  # reserved box the meme can never exceed
+        # whatever width is left after the cam - guarantees the meme window,
+        # however wide the meme, always lands on screen
+        meme_max_w = screen_w - LEFT - cam_w - GAP - RIGHT
 
         cv2.moveWindow("Camera", LEFT, TOP)
         cv2.moveWindow("Meme", LEFT + cam_w + GAP, TOP)

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -79,15 +79,6 @@ GESTURE_MEMES = {
 VIDEO_GESTURES = {"spinCat"}
 
 STABLE_FRAMES_REQUIRED = 5
-# Leaving a gesture that's already on screen takes more consecutive frames
-# than entering one does. Finger classification uses a hard angle cutoff,
-# so a finger held near it flickers: in a real recording of simply holding
-# one finger up, oneFingerUp was interrupted 56 times, mostly by fist -
-# interruptions of 2 frames at the median, but 12 of them lasted 5+ frames
-# and so survived the entry threshold. Requiring 12 frames to leave
-# filters 49 of the 56 while still reacting to a real gesture change in
-# under half a second.
-STABLE_FRAMES_TO_LEAVE = 12
 DEFAULT_FALLBACK_MS = 600
 FACE_STALE_MS = 1200
 
@@ -706,10 +697,7 @@ def detection_loop(
             candidate_gesture = gesture
             candidate_streak = 1
 
-        # sticky once committed: cheap to adopt a gesture from rest, but a
-        # gesture already on screen takes noticeably longer to displace
-        needed = STABLE_FRAMES_REQUIRED if current_gesture == "default" else STABLE_FRAMES_TO_LEAVE
-        if candidate_streak >= needed and gesture != current_gesture:
+        if candidate_streak >= STABLE_FRAMES_REQUIRED and gesture != current_gesture:
             current_gesture = gesture
             if gesture in VIDEO_GESTURES:
                 if gesture == "spinCat":

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -620,6 +620,13 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
+        # right edge of the Meme window, pinned at its starting position -
+        # as the meme's width changes each frame, we re-move the window so
+        # this edge stays put and the window grows/shrinks leftward instead
+        # of rightward off screen
+        first_frame = shared_frame.get()
+        meme_right_x = 720 + fit_to_height(memes["_current"], first_frame.shape[0]).shape[1]
+
         while not stop_event.is_set():
             frame = shared_frame.get()
             if frame is None:
@@ -646,6 +653,7 @@ def main():
 
             cv2.imshow("Camera", frame)
             cv2.imshow("Meme", meme_view)
+            cv2.moveWindow("Meme", meme_right_x - meme_view.shape[1], 80)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -30,6 +30,7 @@ Press q or ESC to quit.
 
 import math
 import random
+import threading
 import time
 from pathlib import Path
 
@@ -418,10 +419,137 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-def fit_to_height(img, height):
-    h, w = img.shape[:2]
-    scale = height / h
-    return cv2.resize(img, (int(w * scale), height))
+# size a window to its own content's aspect ratio, maximized within a given
+# box, instead of forcing content into a fixed-aspect box (which either
+# crops part of the picture off or wastes space with letterbox bars).
+def fit_dims(img_w, img_h, box_w, box_h):
+    scale = min(box_w / img_w, box_h / img_h)
+    return max(1, int(img_w * scale)), max(1, int(img_h * scale))
+
+
+def get_screen_size():
+    """Query the actual display resolution (via a throwaway Tk root) so
+    windows can be sized/placed to fill the screen instead of guessing."""
+    try:
+        import tkinter as tk
+        root = tk.Tk()
+        root.withdraw()
+        w, h = root.winfo_screenwidth(), root.winfo_screenheight()
+        root.destroy()
+        return w, h
+    except Exception:
+        return 1440, 900
+
+
+# The web version stays smooth under load because the <video> tag renders on
+# its own, independent of the JS detection loop - the loop just reads
+# whatever frame happens to be current. cv2.imshow has no such decoupling:
+# if capture/detect/draw/show all happen in one loop, display fps is capped
+# by mediapipe's (CPU-bound, here) inference time. So capture and detection
+# run in their own free-running threads, and the display loop only ever
+# grabs the latest frame + latest detection result - display fps is then
+# bounded by the camera, not by mediapipe.
+class SharedFrame:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.frame = None
+
+    def set(self, frame):
+        with self.lock:
+            self.frame = frame
+
+    def get(self):
+        with self.lock:
+            return self.frame
+
+
+class SharedDetection:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.hand_result = None
+        self.gesture = "default"
+
+    def set(self, hand_result, gesture):
+        with self.lock:
+            self.hand_result = hand_result
+            self.gesture = gesture
+
+    def get(self):
+        with self.lock:
+            return self.hand_result, self.gesture
+
+
+def capture_loop(cap, shared_frame, stop_event):
+    while not stop_event.is_set():
+        ok, frame = cap.read()
+        if not ok:
+            stop_event.set()
+            break
+        shared_frame.set(cv2.flip(frame, 1))  # mirror, like a selfie cam
+
+
+def detection_loop(
+    hand_landmarker,
+    face_landmarker,
+    shared_frame,
+    shared_detection,
+    state,
+    memes,
+    flow_log,
+    stop_event,
+):
+    prev_flow_gray = None
+    current_gesture = "default"
+    candidate_gesture = "default"
+    candidate_streak = 0
+    last_non_default_at = time.time() * 1000
+    start_time = time.time()
+
+    while not stop_event.is_set():
+        frame = shared_frame.get()
+        if frame is None:
+            time.sleep(0.005)
+            continue
+
+        magnitude, coherence, prev_flow_gray = frame_flow_signal(frame, prev_flow_gray)
+        state.update_flow(magnitude, coherence)
+        flow_log.write(
+            f"{time.time() * 1000:.0f},{magnitude:.4f},{coherence:.4f},"
+            f"{state.last_flow_score_debug:.4f},{state.last_flow_fraction_debug:.4f},"
+            f"{state.last_flow_peak_debug:.4f},{current_gesture}\n"
+        )
+
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        mp_image = Image(image_format=ImageFormat.SRGB, data=rgb)
+        ts_ms = int((time.time() - start_time) * 1000)
+
+        hand_result = hand_landmarker.detect_for_video(mp_image, ts_ms)
+        face_result = face_landmarker.detect_for_video(mp_image, ts_ms)
+        state.update_face(face_result)
+
+        gesture = state.decide(hand_result)
+
+        now = time.time() * 1000
+        if gesture == candidate_gesture:
+            candidate_streak += 1
+        else:
+            candidate_gesture = gesture
+            candidate_streak = 1
+
+        if candidate_streak >= STABLE_FRAMES_REQUIRED and gesture != current_gesture:
+            current_gesture = gesture
+            if gesture not in VIDEO_GESTURES:
+                memes["_current"] = random.choice(memes[gesture])
+            elif gesture == "spinCat":
+                memes["_spin_restart"] = True
+
+        if gesture != "default":
+            last_non_default_at = now
+        elif now - last_non_default_at > DEFAULT_FALLBACK_MS and current_gesture != "default":
+            current_gesture = "default"
+            memes["_current"] = random.choice(memes["default"])
+
+        shared_detection.set(hand_result, current_gesture)
 
 
 def main():
@@ -442,6 +570,8 @@ def main():
     )
 
     memes = load_memes()
+    memes["_current"] = random.choice(memes["default"])
+    memes["_spin_restart"] = False
 
     # every frame's flow numbers get logged here, timestamped - so we can
     # look at exactly what a real, full-effort spin looked like afterward
@@ -464,85 +594,102 @@ def main():
     cap = cv2.VideoCapture(0)
     if not cap.isOpened():
         raise RuntimeError("Could not open webcam (index 0)")
+    # ask for a proper resolution and fps - an unconfigured VideoCapture
+    # often defaults to a low-res mode (this was the actual "quality" gap
+    # vs. the web version, which requests 640x480 but through getUserMedia's
+    # own negotiation that tends to pick a much better encode than
+    # AVFoundation's default). MJPG gives the camera more bandwidth
+    # headroom to hit both the resolution and the fps target.
+    cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+    cap.set(cv2.CAP_PROP_FPS, 30)
+    cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)  # always grab the newest frame, not a queued stale one
 
-    cv2.namedWindow("Camera")
-    cv2.namedWindow("Meme")
-    cv2.moveWindow("Camera", 40, 80)
-    cv2.moveWindow("Meme", 720, 80)
+    CAM_WINDOW, MEME_WINDOW = "Camera", "Meme"
+    screen_w, screen_h = get_screen_size()
+    TOP_MARGIN = 60  # menu bar + window title bar, so windows don't get placed under them
+    avail_w, avail_h = screen_w // 2, screen_h - TOP_MARGIN
 
     state = GestureState()
-    current_gesture = "default"
-    candidate_gesture = "default"
-    candidate_streak = 0
-    last_non_default_at = time.time() * 1000
-    current_meme = random.choice(memes["default"])
-    prev_flow_gray = None
+    shared_frame = SharedFrame()
+    shared_detection = SharedDetection()
+    stop_event = threading.Event()
 
-    start_time = time.time()
+    cap_thread = threading.Thread(target=capture_loop, args=(cap, shared_frame, stop_event), daemon=True)
+    det_thread = threading.Thread(
+        target=detection_loop,
+        args=(
+            hand_landmarker,
+            face_landmarker,
+            shared_frame,
+            shared_detection,
+            state,
+            memes,
+            flow_log,
+            stop_event,
+        ),
+        daemon=True,
+    )
+    cap_thread.start()
+    det_thread.start()
+
     try:
-        while True:
-            ok, frame = cap.read()
-            if not ok:
-                break
-            frame = cv2.flip(frame, 1)  # mirror, like a selfie cam
+        # wait for the first camera frame so we know its native aspect ratio
+        # before sizing the window (and so the window doesn't flash empty)
+        while shared_frame.get() is None and not stop_event.is_set():
+            time.sleep(0.01)
 
-            magnitude, coherence, prev_flow_gray = frame_flow_signal(frame, prev_flow_gray)
-            state.update_flow(magnitude, coherence)
-            flow_log.write(
-                f"{time.time() * 1000:.0f},{magnitude:.4f},{coherence:.4f},"
-                f"{state.last_flow_score_debug:.4f},{state.last_flow_fraction_debug:.4f},"
-                f"{state.last_flow_peak_debug:.4f},{current_gesture}\n"
-            )
+        first_frame = shared_frame.get()
+        cam_w, cam_h = fit_dims(first_frame.shape[1], first_frame.shape[0], avail_w, avail_h)
 
-            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            mp_image = Image(image_format=ImageFormat.SRGB, data=rgb)
-            ts_ms = int((time.time() - start_time) * 1000)
+        cv2.namedWindow(CAM_WINDOW, cv2.WINDOW_NORMAL)
+        cv2.resizeWindow(CAM_WINDOW, cam_w, cam_h)
+        cv2.moveWindow(CAM_WINDOW, 0, TOP_MARGIN)  # left edge pinned to screen's left edge
 
-            hand_result = hand_landmarker.detect_for_video(mp_image, ts_ms)
-            face_result = face_landmarker.detect_for_video(mp_image, ts_ms)
-            state.update_face(face_result)
+        cv2.namedWindow(MEME_WINDOW, cv2.WINDOW_NORMAL)
 
-            gesture = state.decide(hand_result)
+        while not stop_event.is_set():
+            frame = shared_frame.get()
+            if frame is None:
+                continue
+            frame = frame.copy()
 
-            now = time.time() * 1000
-            if gesture == candidate_gesture:
-                candidate_streak += 1
-            else:
-                candidate_gesture = gesture
-                candidate_streak = 1
-
-            if candidate_streak >= STABLE_FRAMES_REQUIRED and gesture != current_gesture:
-                current_gesture = gesture
-                if gesture not in VIDEO_GESTURES:
-                    current_meme = random.choice(memes[gesture])
-                elif gesture == "spinCat":
-                    spin_video_cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
-
-            if gesture != "default":
-                last_non_default_at = now
-            elif now - last_non_default_at > DEFAULT_FALLBACK_MS and current_gesture != "default":
-                current_gesture = "default"
-                current_meme = random.choice(memes["default"])
-
-            draw_landmarks(frame, hand_result)
+            hand_result, current_gesture = shared_detection.get()
+            if hand_result is not None:
+                draw_landmarks(frame, hand_result)
             draw_debug_hud(frame, state, current_gesture)
 
             if current_gesture == "spinCat":
+                if memes["_spin_restart"]:
+                    spin_video_cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                    memes["_spin_restart"] = False
                 vframe = next_spin_frame()
-                meme_view = (
-                    fit_to_height(vframe, frame.shape[0])
-                    if vframe is not None
-                    else fit_to_height(current_meme, frame.shape[0])
-                )
+                meme_img = vframe if vframe is not None else memes["_current"]
             else:
-                meme_view = fit_to_height(current_meme, frame.shape[0])
-            cv2.imshow("Camera", frame)
-            cv2.imshow("Meme", meme_view)
+                meme_img = memes["_current"]
 
+            meme_w, meme_h = fit_dims(meme_img.shape[1], meme_img.shape[0], avail_w, avail_h)
+
+            cv2.imshow(CAM_WINDOW, cv2.resize(frame, (cam_w, cam_h)))
+            cv2.imshow(MEME_WINDOW, cv2.resize(meme_img, (meme_w, meme_h)))
+            # macOS/Cocoa backend sometimes ignores resizeWindow if it's not
+            # re-applied after imshow, so pin the size every frame
+            cv2.resizeWindow(MEME_WINDOW, meme_w, meme_h)
+            # anchor the Meme window's RIGHT edge to the screen's right edge,
+            # so as the meme's width changes the window grows/shrinks
+            # leftward (into the screen) instead of rightward (off it)
+            cv2.moveWindow(MEME_WINDOW, screen_w - meme_w, TOP_MARGIN)
+
+            # no delay beyond what's needed to pump the GUI event loop - the
+            # display rate is bounded by the camera thread, not by this wait
             key = cv2.waitKey(1) & 0xFF
             if key == ord("q") or key == 27:
                 break
     finally:
+        stop_event.set()
+        cap_thread.join(timeout=1)
+        det_thread.join(timeout=1)
         cap.release()
         spin_video_cap.release()
         flow_log.close()

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -590,7 +590,6 @@ def main():
     cv2.namedWindow("Camera")
     cv2.namedWindow("Meme")
     cv2.moveWindow("Camera", 40, 80)
-    cv2.moveWindow("Meme", 720, 80)
 
     state = GestureState()
     shared_frame = SharedFrame()
@@ -620,6 +619,14 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
+        # place Meme just to the right of the Camera window's real width
+        # (not a hardcoded x - the cam capture resolution changed, so a
+        # fixed x would overlap it), and prime the window's actual OS rect
+        # so the drag-aware anchoring below has a starting position to read
+        first_frame = shared_frame.get()
+        cv2.imshow("Meme", fit_to_height(memes["_current"], first_frame.shape[0]))
+        cv2.moveWindow("Meme", 40 + first_frame.shape[1] + 40, 80)
+
         while not stop_event.is_set():
             frame = shared_frame.get()
             if frame is None:
@@ -644,8 +651,17 @@ def main():
             else:
                 meme_view = fit_to_height(memes["_current"], frame.shape[0])
 
+            # read the window's CURRENT on-screen position before touching
+            # it - if the user dragged it since last frame, this reflects
+            # that. Then grow leftward from there (keep the right edge
+            # where it is) instead of snapping back to a fixed spot, so
+            # dragging the window still works.
+            meme_x, meme_y, meme_old_w, _ = cv2.getWindowImageRect("Meme")
+            right_edge = meme_x + meme_old_w
+
             cv2.imshow("Camera", frame)
             cv2.imshow("Meme", meme_view)
+            cv2.moveWindow("Meme", right_edge - meme_view.shape[1], meme_y)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -11,8 +11,7 @@ Gestures:
   one finger up     -> memes/professorcat.jpg
   fist / punch      -> memes/punchcat.jpg
   shhh              -> memes/shhcat.jpg
-  two fingers together (both hands, tips touching) -> memes/uwucat.jpg, memes/uwucatt.jpg,
-                                                        memes/fingers together muehehe .jpg
+  two fingers together (both hands, tips touching) -> memes/uwucat.jpg, memes/uwucatt.jpg
   hand covering face -> memes/hand cover face .jpg
   crash-out cat (two hands up beside the face)            -> memes/crashout cat .jpg
   two hands on head                                        -> memes/two hands on head .jpg
@@ -64,7 +63,7 @@ GESTURE_MEMES = {
     "oneFingerUp": ["professorcat.jpg"],
     "fist": ["punchcat.jpg"],
     "shhh": ["shhcat.jpg"],
-    "twoFingersTogether": ["uwucat.jpg", "uwucatt.jpg", "fingers together muehehe .jpg"],
+    "twoFingersTogether": ["uwucat.jpg", "uwucatt.jpg"],
     "handCoverFace": ["hand cover face .jpg"],
     "crashOutCat": ["crashout cat .jpg"],
     "twoHandsOnHead": ["two hands on head .jpg"],

--- a/gesture_meme.py
+++ b/gesture_meme.py
@@ -419,10 +419,35 @@ def draw_landmarks(frame, hand_result):
             cv2.circle(frame, (x, y), 4, (60, 140, 255), -1)
 
 
-def fit_to_height(img, height):
-    h, w = img.shape[:2]
-    scale = height / h
-    return cv2.resize(img, (int(w * scale), height))
+def get_screen_size():
+    """Actual display resolution, via a throwaway Tk root, so the two
+    windows can be sized to fit on screen instead of guessing."""
+    try:
+        import tkinter as tk
+        root = tk.Tk()
+        root.withdraw()
+        w, h = root.winfo_screenwidth(), root.winfo_screenheight()
+        root.destroy()
+        return w, h
+    except Exception:
+        return 1440, 900
+
+
+# The Meme window is a plain autosizing cv2 window, so its size follows
+# whatever image we hand it - and since a window keeps its top-left corner
+# fixed, every meme with a different width made the window grow rightward.
+# Rather than chasing that by moving the window every frame (which fights
+# the user dragging it), draw every meme onto a canvas of one constant
+# size: the window is then created once at that size and never resizes at
+# all. The canvas is sized to the widest meme so nothing is ever cropped,
+# and narrower memes are centered in it.
+def paste_centered(img, canvas_w, canvas_h):
+    scale = min(canvas_w / img.shape[1], canvas_h / img.shape[0])
+    w, h = max(1, int(img.shape[1] * scale)), max(1, int(img.shape[0] * scale))
+    canvas = np.zeros((canvas_h, canvas_w, 3), dtype=img.dtype)
+    x, y = (canvas_w - w) // 2, (canvas_h - h) // 2
+    canvas[y:y + h, x:x + w] = cv2.resize(img, (w, h))
+    return canvas
 
 
 # The web version stays smooth under load because the <video> tag renders on
@@ -554,6 +579,11 @@ def main():
     )
 
     memes = load_memes()
+    # widest aspect ratio of any meme - the fixed canvas is sized to this so
+    # even the widest one fits without being cropped or shrunk. Computed
+    # before the bookkeeping keys below are added, while every value is
+    # still a list of images.
+    widest_meme_aspect = max(img.shape[1] / img.shape[0] for imgs in memes.values() for img in imgs)
     memes["_current"] = random.choice(memes["default"])
     memes["_spin_restart"] = False
 
@@ -567,6 +597,11 @@ def main():
     spin_video_cap = cv2.VideoCapture(str(MEMES / GESTURE_MEMES["spinCat"][0]))
     if not spin_video_cap.isOpened():
         raise FileNotFoundError(f"missing meme file: {MEMES / GESTURE_MEMES['spinCat'][0]}")
+    # the spin video is a meme too, so it has to fit the canvas as well
+    spin_w = spin_video_cap.get(cv2.CAP_PROP_FRAME_WIDTH)
+    spin_h = spin_video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
+    if spin_w > 0 and spin_h > 0:
+        widest_meme_aspect = max(widest_meme_aspect, spin_w / spin_h)
 
     def next_spin_frame():
         ok, vframe = spin_video_cap.read()
@@ -619,13 +654,25 @@ def main():
         while shared_frame.get() is None and not stop_event.is_set():
             time.sleep(0.01)
 
-        # place Meme just to the right of the Camera window's real width
-        # (not a hardcoded x - the cam capture resolution changed, so a
-        # fixed x would overlap it), and prime the window's actual OS rect
-        # so the drag-aware anchoring below has a starting position to read
+        # Both windows are sized ONCE here and never resize again. Capture
+        # runs at 1280x720 for quality and detection accuracy, but that's
+        # far too wide to show next to a meme on a normal screen, so pick
+        # one shared display height that lets cam + widest meme sit side by
+        # side within the screen. Sizes are constant for the whole session,
+        # so neither window ever grows and both stay freely draggable.
         first_frame = shared_frame.get()
-        cv2.imshow("Meme", fit_to_height(memes["_current"], first_frame.shape[0]))
-        cv2.moveWindow("Meme", 40 + first_frame.shape[1] + 40, 80)
+        cam_aspect = first_frame.shape[1] / first_frame.shape[0]
+        screen_w, screen_h = get_screen_size()
+        LEFT, GAP, RIGHT, TOP, BOTTOM = 40, 40, 40, 80, 60
+        h = min(
+            screen_h - TOP - BOTTOM,
+            int((screen_w - LEFT - GAP - RIGHT) / (cam_aspect + widest_meme_aspect)),
+        )
+        cam_w, cam_h = int(cam_aspect * h), h
+        canvas_w, canvas_h = int(widest_meme_aspect * h), h
+
+        cv2.moveWindow("Camera", LEFT, TOP)
+        cv2.moveWindow("Meme", LEFT + cam_w + GAP, TOP)
 
         while not stop_event.is_set():
             frame = shared_frame.get()
@@ -643,25 +690,17 @@ def main():
                     spin_video_cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
                     memes["_spin_restart"] = False
                 vframe = next_spin_frame()
-                meme_view = (
-                    fit_to_height(vframe, frame.shape[0])
-                    if vframe is not None
-                    else fit_to_height(memes["_current"], frame.shape[0])
-                )
+                meme_img = vframe if vframe is not None else memes["_current"]
             else:
-                meme_view = fit_to_height(memes["_current"], frame.shape[0])
+                meme_img = memes["_current"]
 
-            # read the window's CURRENT on-screen position before touching
-            # it - if the user dragged it since last frame, this reflects
-            # that. Then grow leftward from there (keep the right edge
-            # where it is) instead of snapping back to a fixed spot, so
-            # dragging the window still works.
-            meme_x, meme_y, meme_old_w, _ = cv2.getWindowImageRect("Meme")
-            right_edge = meme_x + meme_old_w
+            # always the same canvas size, so the window never resizes and
+            # therefore never grows in any direction - and since we never
+            # move it, dragging it works normally
+            meme_view = paste_centered(meme_img, canvas_w, canvas_h)
 
-            cv2.imshow("Camera", frame)
+            cv2.imshow("Camera", cv2.resize(frame, (cam_w, cam_h)))
             cv2.imshow("Meme", meme_view)
-            cv2.moveWindow("Meme", right_edge - meme_view.shape[1], meme_y)
 
             # no delay beyond what's needed to pump the GUI event loop - the
             # display rate is bounded by the camera thread, not by this wait


### PR DESCRIPTION
- **Decouple cam display from detection fps, bump capture quality, anchor meme window right**
- **Balance cam/meme window sizes by aspect ratio, not a fixed half-width split**
- **Cam window fixed for the session, meme floats centered on top of it**
- **Revert "Cam window fixed for the session, meme floats centered on top of it"**
- **Fix cam window resizing when the meme changes size**
- **Switch cam capture to 4:3 (960x720) for a bigger cam window**
- **Cam window sized within 2/3 screen width instead of half**
- **Meme window always fills full height, overlapping cam instead of shrinking**
- **Revert "Meme window always fills full height, overlapping cam instead of shrinking"**
- **Reserve exactly enough room for the biggest meme, with a small gap**
- **Revert to the repo's original two-window layout, keep the fps/quality fixes**
- **Anchor Meme window's right edge so it grows leftward, not rightward**
- **Revert "Anchor Meme window's right edge so it grows leftward, not rightward"**
- **Adapt Meme window position to real cam size, fix left-growth without blocking drag**
- **Fix meme window growth at the source: one constant canvas, fixed window sizes**
- **Replace tkinter screen detection with osascript to fix startup crash**
- **Drop letterbox canvas, size layout for still memes so the cam gets bigger**
- **Scale both windows up ~10%**
- **Make the debug readout legible**
- **Add screaming and huh gestures, fix duplicated HUD text, compact the readout**
- **Measure mouth openness against face height, show art-less gestures in the readout**
- **Log face signals so mouth/roll thresholds can be tuned from recordings**
- **Stop the meme flapping between images while a gesture is held**
- **Drop profcat from oneFingerUp, keep professorcat only**
- **Log hand-pair signals to diagnose twoFingersTogether losing to crashOutCat**
- **Rotate memes on rest instead of re-rolling, log per-finger flags**
- **Drop the leave-hysteresis that made gestures slow to switch**
- **Drop the muehehe image from twoFingersTogether, it overlaps uwucat**
