### PR TITLE
Document browser setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ memes/            meme images (+ one video, unused for now)
 models/           MediaPipe .task model files used by the desktop version
 requirements.txt  Python dependencies
 ```
+## Running the Browser Version
+
+1. Open a terminal in this repository.
+2. Run `python -m http.server 8000`.
+3. Open `http://localhost:8000` in your browser.
+4. Allow camera access when prompted.


### PR DESCRIPTION
## What changed

Added instructions for running the browser version locally.

## How to run

1. Run `python -m http.server 8000`
2. Open `http://localhost:8000`
3. Allow camera access when prompted.

## Testing

Tested the browser version locally and confirmed that the Cat Cam works correctly.